### PR TITLE
Parse spectrum specs

### DIFF
--- a/pbrtParser/impl/semantic/BinaryFileFormat.cpp
+++ b/pbrtParser/impl/semantic/BinaryFileFormat.cpp
@@ -72,6 +72,8 @@ namespace pbrt {
 
     TYPE_DIFFUSE_AREALIGHT_BB,
     TYPE_DIFFUSE_AREALIGHT_RGB,
+
+    TYPE_SPECTRUM,
   };
     
   /*! a simple buffer for binary data */
@@ -218,6 +220,8 @@ namespace pbrt {
         return std::make_shared<DiffuseAreaLightBB>();
       case TYPE_DIFFUSE_AREALIGHT_RGB:
         return std::make_shared<DiffuseAreaLightRGB>();
+      case TYPE_SPECTRUM:
+        return std::make_shared<Spectrum>();
       default:
         std::cerr << "unknown entity type tag " << typeTag << " in binary file" << std::endl;
         return Entity::SP();
@@ -673,6 +677,23 @@ namespace pbrt {
   }
   
   
+  // ==================================================================
+  // Spectrum
+  // ==================================================================
+
+  /*! serialize out to given binary writer */
+  int Spectrum::writeTo(BinaryWriter &binary) 
+  {
+    binary.write(spd);
+    return TYPE_SPECTRUM;
+  }
+
+
+  /*! serialize out to given binary reader */
+  void Spectrum::readFrom(BinaryReader &binary) 
+  {
+    binary.read(spd);
+  }
 
   // ==================================================================
   // Texture

--- a/pbrtParser/impl/semantic/Materials.cpp
+++ b/pbrtParser/impl/semantic/Materials.cpp
@@ -125,14 +125,22 @@ namespace pbrt {
       else if (name == "eta") {
         if (in->hasParam3f(name))
           in->getParam3f(&mat->eta.x,name);
-        else
-          mat->spectrum_eta = in->getParamString(name);
+        else {
+          std::size_t N=0;
+          in->getParamPairNf(nullptr,&N,name);
+          mat->spectrum_eta.spd.resize(N);
+          in->getParamPairNf(mat->spectrum_eta.spd.data(),&N,name);
+        }
       }
       else if (name == "k") {
         if (in->hasParam3f(name))
           in->getParam3f(&mat->k.x,name);
-        else
-          mat->spectrum_k = in->getParamString(name);
+        else {
+          std::size_t N=0;
+          in->getParamPairNf(nullptr,&N,name);
+          mat->spectrum_k.spd.resize(N);
+          in->getParamPairNf(mat->spectrum_k.spd.data(),&N,name);
+        }
       }
       else if (name == "bumpmap") {
         mat->map_bump = findOrCreateTexture(in->getParamTexture(name));

--- a/pbrtParser/impl/syntactic/Lexer.h
+++ b/pbrtParser/impl/syntactic/Lexer.h
@@ -60,7 +60,10 @@ namespace pbrt {
       Loc(const std::shared_ptr<File> &file=std::shared_ptr<File>()) : file(file), line(1), col(0) { }
       //! copy-constructor
       Loc(const Loc &loc) = default;
-      Loc(Loc &&) = default;
+      Loc(Loc &&loc) = default;
+      //! assignment
+      Loc& operator=(const Loc &other) = default;
+      Loc& operator=(Loc &&) = default;
 
       //! pretty-print
       std::string toString() const {
@@ -83,15 +86,19 @@ namespace pbrt {
       Token(const Token &other) = default;
       Token(Token &&) = default;
 
+      //! assignment
+      Token& operator=(const Token &other) = default;
+      Token& operator=(Token &&) = default;
+
       //! valid token
       explicit operator bool() { return type != TOKEN_TYPE_NONE; }
     
       //! pretty-print
       std::string toString() const { return loc.toString() + ": '" + text + "'"; }
       
-      const Loc         loc = {};
-      const Type        type = TOKEN_TYPE_NONE;
-      const std::string text = "";
+      Loc         loc = {};
+      Type        type = TOKEN_TYPE_NONE;
+      std::string text = "";
     };
 
     /*! class that does the lexing - ie, the breaking up of an input

--- a/pbrtParser/impl/syntactic/Parser.cpp
+++ b/pbrtParser/impl/syntactic/Parser.cpp
@@ -152,7 +152,7 @@ namespace pbrt {
       } else if (type == "rgb") {
         ret = std::make_shared<ParamArray<float> >(type);
       } else if (type == "spectrum") {
-        ret = std::make_shared<ParamArray<std::string>>(type);
+        ret = std::make_shared<ParamArray<float>>(type);
       } else if (type == "integer") {
         ret = std::make_shared<ParamArray<int>>(type);
       } else if (type == "bool") {
@@ -195,6 +195,21 @@ namespace pbrt {
         if (type == "texture") {
           std::dynamic_pointer_cast<ParamArray<Texture>>(ret)->texture 
             = getTexture(value);
+        } else if (type == "spectrum") {
+          /* parse (wavelength, value) pairs from file */
+          std::string includedFileName = value;
+          if (includedFileName[0] != '/') {
+            includedFileName = rootNamePath+"/"+includedFileName;
+          }
+          // if (dbg)
+          std::cout << "... including spd file '" << includedFileName << " ..." << std::endl;
+          auto tokens = std::make_shared<Lexer>(includedFileName);
+          Token t = tokens->next();
+          while (t)
+          {
+            ret->add(t.text);
+            t = tokens->next();
+          }
         } else {
           ret->add(value);
         }

--- a/pbrtParser/impl/syntactic/Scene.cpp
+++ b/pbrtParser/impl/syntactic/Scene.cpp
@@ -18,6 +18,7 @@
 // std
 #include <iostream>
 #include <sstream>
+#include <utility>
 
 /*! namespace for all things pbrt parser, both syntactical *and* semantical parser */
 namespace pbrt {
@@ -144,6 +145,48 @@ namespace pbrt {
     // ==================================================================
     // ParamSet
     // ==================================================================
+    bool ParamSet::getParamPairNf(pairNf::value_type *result, std::size_t* N, const std::string &name) const
+    {
+      std::map<std::string,std::shared_ptr<Param> >::const_iterator it=param.find(name);
+      if (it == param.end())
+        return 0;
+      std::shared_ptr<Param> pr = it->second;
+      const std::shared_ptr<ParamArray<float>> p = std::dynamic_pointer_cast<ParamArray<float>>(pr);
+      if (!p)
+        throw std::runtime_error("found param of given name, but of wrong type! (name was '"+name+"'");
+      if (p->getSize() % 2 != 0)
+        throw std::runtime_error("found param of given name and type, but components aren't pairs! (PairNf, name='"+name+"'");
+      *N = p->getSize()/2;
+      if (result != nullptr)
+      {
+        for (std::size_t i=0; i<p->getSize(); i+=2)
+        {
+          result[i/2] = std::make_pair(p->get(i), p->get(i+1));
+        }
+      }
+      return true;
+    }
+
+    pairNf ParamSet::getParamPairNf(const std::string &name, const pairNf &fallBack) const
+    {
+      std::map<std::string,std::shared_ptr<Param> >::const_iterator it=param.find(name);
+      if (it == param.end())
+        return fallBack;
+      std::shared_ptr<Param> pr = it->second;
+      const std::shared_ptr<ParamArray<float>> p = std::dynamic_pointer_cast<ParamArray<float>>(pr);
+      if (!p)
+        throw std::runtime_error("3f: found param of given name, but of wrong type! (name was '"+name+"'");
+      if (p->getSize() % 2 != 0)
+        throw std::runtime_error("found param of given name and type, but components aren't pairs! (PairNf, name='"+name+"'");
+      std::size_t N = p->getSize()/2;
+      pairNf res(N);
+      for (std::size_t i=0; i<p->getSize(); i+=2)
+      {
+        res[i/2] = std::make_pair(p->get(i), p->get(i+1));
+      }
+      return res;
+    }
+
     bool ParamSet::getParam3f(float *result, const std::string &name) const
     {
       std::map<std::string,std::shared_ptr<Param> >::const_iterator it=param.find(name);

--- a/pbrtParser/impl/syntactic/Scene.h
+++ b/pbrtParser/impl/syntactic/Scene.h
@@ -87,6 +87,7 @@ namespace pbrt {
     using vec4i    = math::vec4i;
     using affine3f = math::affine3f;
     using box3f    = math::box3f;
+    using pairNf   = math::pairNf;
 
     /*! start-time and end-time transform - PBRT allows for specifying
       transform at both 'start' and 'end' time, to allow for linear
@@ -195,10 +196,13 @@ namespace pbrt {
       ParamSet(ParamSet &&) = default;
       ParamSet(const ParamSet &) = default;
 
+      /*! query number of (float,float) pairs N. Store in result if the former != NULL */
+      bool getParamPairNf(pairNf::value_type *result, std::size_t* N, const std::string &name) const;
       /*! query parameter of 3f type, and if found, store in result and
         return true; else return false */
       bool getParam3f(float *result, const std::string &name) const;
       bool getParam2f(float *result, const std::string &name) const;
+      math::pairNf getParamPairNf(const std::string &name, const math::pairNf &fallBack) const;
       math::vec3f getParam3f(const std::string &name, const math::vec3f &fallBack) const;
       math::vec2f getParam2f(const std::string &name, const math::vec2f &fallBack) const;
 #if defined(PBRT_PARSER_VECTYPE_NAMESPACE)

--- a/pbrtParser/include/pbrtParser/Scene.h
+++ b/pbrtParser/include/pbrtParser/Scene.h
@@ -41,6 +41,7 @@ namespace pbrt {
   using vec4i    = PBRT_PARSER_VECTYPE_NAMESPACE::vec4i;
   using affine3f = PBRT_PARSER_VECTYPE_NAMESPACE::affine3f;
   using box3f    = PBRT_PARSER_VECTYPE_NAMESPACE::box3f;
+  using pairNf   = PBRT_PARSER_VECTYPE_NAMESPACE::pairNf;
 #else
   using vec2f    = pbrt::math::vec2f;
   using vec3f    = pbrt::math::vec3f;
@@ -50,6 +51,7 @@ namespace pbrt {
   using vec4i    = pbrt::math::vec4i;
   using affine3f = pbrt::math::affine3f;
   using box3f    = pbrt::math::box3f;
+  using pairNf   = pbrt::math::pairNf;
 #endif
     
   /*! internal class used for serializing a scene graph to/from disk */
@@ -133,7 +135,22 @@ namespace pbrt {
 
     float temperature, scale;
   };
-  
+
+  /*! a spectrum is defined by a spectral power distribution,
+    i.e. a list of (wavelength, value) pairs */
+  struct Spectrum : public Entity {
+    typedef std::shared_ptr<Spectrum> SP;
+
+    /*! pretty-printer, for debugging */
+    virtual std::string toString() const override { return "Spectrum"; }
+    /*! serialize out to given binary writer */
+    virtual int writeTo(BinaryWriter &) override;
+    /*! serialize _in_ from given binary file reader */
+    virtual void readFrom(BinaryReader &) override;
+
+    pairNf spd;
+  };
+
   struct Texture : public Entity {
     typedef std::shared_ptr<Texture> SP;
     
@@ -333,9 +350,9 @@ namespace pbrt {
     Texture::SP map_vRoughness;
     bool remapRoughness { false };
     vec3f       eta  { 1.f, 1.f, 1.f };
-    std::string spectrum_eta;
+    Spectrum spectrum_eta;
     vec3f       k    { 1.f, 1.f, 1.f };
-    std::string spectrum_k;
+    Spectrum spectrum_k;
     Texture::SP map_bump;
   };
     

--- a/pbrtParser/include/pbrtParser/math.h
+++ b/pbrtParser/include/pbrtParser/math.h
@@ -38,6 +38,8 @@
 #include <math.h> // using cmath causes issues under Windows
 #include <cfloat>
 #include <limits>
+#include <utility>
+#include <vector>
 
 /*! \file pbrt/Parser.h *Internal* parser class used by \see
   pbrt_parser::Scene::parseFromFile() - as end user, you should
@@ -120,6 +122,7 @@ namespace pbrt {
       void extend(const vec3f& a);
       void extend(const box3f& a);
     };
+    typedef std::vector<std::pair<float, float>> pairNf;
 
     inline vec3f operator-(const vec3f& a) { return vec3f(-a.x, -a.y, -a.z); }
     inline vec3f operator-(const vec3f& a, const vec3f& b) { return vec3f(a.x - b.x, a.y - b.y, a.z - b.z); }


### PR DESCRIPTION
> I will parse auxiliary .ply files as part of the parsing process, but will not parse texture formats, ptex, spectrum specs, etc.

I was wondering if you would at least consider parsing the spectrum specs? PBRT's SPD format is pretty simple, proprietary, and also very specific - SPDs are defined by either a floating point array or an included spd file storing (wavelength, value) pairs.

The PR would implement this and (exemplarily) parse the SPDs of the metal material. The PR can be verified by parsing e.g. the crown.pbrt, pavilion.pbrt, or bmw_m6.pbrt files. There's no pbrt file with an inline spectrum I know of, but a material with this prop can easily be created for verification. (Note that the file format also allows for #comments in spd files, I haven't found any files having these and thus delayed this until later / depending on the decision about this feature.)

I use a vector<pair<float,float>> to store the SPDs. There are of course alternative ways to implement this that e.g. wouldn't use the STL. I usually tend to not expose STL data structures in the interface but I have seen that the Scene.h header generally does so. Just let me know if you'd prefer implementing this in a different way and I would adapt the PR.