### PR TITLE
Compile fix

### DIFF
--- a/apps/pbrt2obj.cpp
+++ b/apps/pbrt2obj.cpp
@@ -107,7 +107,7 @@ namespace pbrt {
         inFileName = arg;
       }          
     }
-    out = std::ofstream(outFileName);
+    out.open(outFileName);
     // out = fopen(outFileName.c_str(),"w");
     assert(out.good());
 


### PR DESCRIPTION
I only stumbled upon this when compiling w/ gcc 4.8.4 on an old Ubuntu 14.04 box. `basic_ostream<>`s aren't copyable, their `operator=(basic_ostream&)` is `delete`d with C++11. (That said, Ubuntu 16.04's gcc and macOS 10.3's clang both swallowed the code somehow which is curious.)