### PR TITLE
Fix Win32 builds

### DIFF
--- a/pbrtParser/CMakeLists.txt
+++ b/pbrtParser/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCES
   impl/syntactic/Scene.cpp
 
   # code for extracting the given entirires from syntactic to semantic
+  impl/semantic/SemanticParser.h
   impl/semantic/Geometry.cpp
   impl/semantic/Camera.cpp
   impl/semantic/Textures.cpp

--- a/pbrtParser/include/pbrtParser/math.h
+++ b/pbrtParser/include/pbrtParser/math.h
@@ -36,7 +36,7 @@
 #endif
 
 #if defined(PBRT_PARSER_DLL_INTERFACE)
-#  ifdef pbrtParser_semantic_EXPORTS
+#  ifdef pbrtParser_EXPORTS
 #    define PBRT_PARSER_INTERFACE PBRT_PARSER_DLL_EXPORT
 #  else
 #    define PBRT_PARSER_INTERFACE PBRT_PARSER_DLL_IMPORT


### PR DESCRIPTION
That one was actually pretty subtle. This only worked before with gcc because there the attributes for import and export are the same, and when the macro would always validate to `xxx_IMPORT` it wouldn't matter.

Tested with msvc 19.10.25019 (Visual Studio 2017) x64.