### PR TITLE
base path + fix for named materials

### DIFF
--- a/pbrtParser/impl/semantic/Materials.cpp
+++ b/pbrtParser/impl/semantic/Materials.cpp
@@ -20,7 +20,7 @@ namespace pbrt {
 
   Material::SP SemanticParser::createMaterial_uber(pbrt::syntactic::Material::SP in)
   {
-    UberMaterial::SP mat = std::make_shared<UberMaterial>();
+    UberMaterial::SP mat = std::make_shared<UberMaterial>(in->name);
     for (auto it : in->param) {
       std::string name = it.first;
       if (name == "Kd") {
@@ -113,7 +113,7 @@ namespace pbrt {
 
   Material::SP SemanticParser::createMaterial_metal(pbrt::syntactic::Material::SP in)
   {
-    MetalMaterial::SP mat = std::make_shared<MetalMaterial>();
+    MetalMaterial::SP mat = std::make_shared<MetalMaterial>(in->name);
     for (auto it : in->param) {
       std::string name = it.first;
       if (name == "roughness") {
@@ -170,7 +170,7 @@ namespace pbrt {
 
   Material::SP SemanticParser::createMaterial_matte(pbrt::syntactic::Material::SP in)
   {
-    MatteMaterial::SP mat = std::make_shared<MatteMaterial>();
+    MatteMaterial::SP mat = std::make_shared<MatteMaterial>(in->name);
     for (auto it : in->param) {
       std::string name = it.first;
       if (name == "Kd") {
@@ -199,7 +199,7 @@ namespace pbrt {
 
   Material::SP SemanticParser::createMaterial_fourier(pbrt::syntactic::Material::SP in)
   {
-    FourierMaterial::SP mat = std::make_shared<FourierMaterial>();
+    FourierMaterial::SP mat = std::make_shared<FourierMaterial>(in->name);
     for (auto it : in->param) {
       std::string name = it.first;
       if (name == "bsdffile") {
@@ -215,7 +215,7 @@ namespace pbrt {
 
   Material::SP SemanticParser::createMaterial_mirror(pbrt::syntactic::Material::SP in)
   {
-    MirrorMaterial::SP mat = std::make_shared<MirrorMaterial>();
+    MirrorMaterial::SP mat = std::make_shared<MirrorMaterial>(in->name);
     for (auto it : in->param) {
       std::string name = it.first;
       if (name == "Kr") {
@@ -237,7 +237,7 @@ namespace pbrt {
 
   Material::SP SemanticParser::createMaterial_substrate(pbrt::syntactic::Material::SP in)
   {
-    SubstrateMaterial::SP mat = std::make_shared<SubstrateMaterial>();
+    SubstrateMaterial::SP mat = std::make_shared<SubstrateMaterial>(in->name);
     for (auto it : in->param) {
       std::string name = it.first;
       if (name == "Kd") {
@@ -284,7 +284,7 @@ namespace pbrt {
 
   Material::SP SemanticParser::createMaterial_disney(pbrt::syntactic::Material::SP in)
   {
-    DisneyMaterial::SP mat = std::make_shared<DisneyMaterial>();
+    DisneyMaterial::SP mat = std::make_shared<DisneyMaterial>(in->name);
 
     in->getParam3f(&mat->color.x,"color");
     mat->anisotropic    = in->getParam1f("anisotropic",    0.f );
@@ -305,7 +305,7 @@ namespace pbrt {
 
   Material::SP SemanticParser::createMaterial_mix(pbrt::syntactic::Material::SP in)
   {
-    MixMaterial::SP mat = std::make_shared<MixMaterial>();
+    MixMaterial::SP mat = std::make_shared<MixMaterial>(in->name);
           
     if (in->hasParamTexture("amount"))
       mat->map_amount = findOrCreateTexture(in->getParamTexture("amount"));
@@ -333,7 +333,7 @@ namespace pbrt {
 
   Material::SP SemanticParser::createMaterial_plastic(pbrt::syntactic::Material::SP in)
   {
-    PlasticMaterial::SP mat = std::make_shared<PlasticMaterial>();
+    PlasticMaterial::SP mat = std::make_shared<PlasticMaterial>(in->name);
     for (auto it : in->param) {
       std::string name = it.first;
       if (name == "Kd") {
@@ -372,7 +372,7 @@ namespace pbrt {
   
   Material::SP SemanticParser::createMaterial_translucent(pbrt::syntactic::Material::SP in)
   {
-    TranslucentMaterial::SP mat = std::make_shared<TranslucentMaterial>();
+    TranslucentMaterial::SP mat = std::make_shared<TranslucentMaterial>(in->name);
 
     in->getParam3f(&mat->transmit.x,"transmit");
     in->getParam3f(&mat->reflect.x,"reflect");
@@ -386,7 +386,7 @@ namespace pbrt {
 
   Material::SP SemanticParser::createMaterial_glass(pbrt::syntactic::Material::SP in)
   {
-    GlassMaterial::SP mat = std::make_shared<GlassMaterial>();
+    GlassMaterial::SP mat = std::make_shared<GlassMaterial>(in->name);
 
     in->getParam3f(&mat->kr.x,"Kr");
     in->getParam3f(&mat->kt.x,"Kt");

--- a/pbrtParser/impl/semantic/importPBRT.cpp
+++ b/pbrtParser/impl/semantic/importPBRT.cpp
@@ -825,11 +825,11 @@ namespace pbrt {
     return ours;
   }
 #endif
-  Scene::SP importPBRT(const std::string &fileName)
+  Scene::SP importPBRT(const std::string &fileName, const std::string &basePath)
   {
     pbrt::syntactic::Scene::SP pbrt;
     if (endsWith(fileName,".pbrt"))
-      pbrt = pbrt::syntactic::Scene::parse(fileName);
+      pbrt = pbrt::syntactic::Scene::parse(fileName, basePath);
     else
       throw std::runtime_error("could not detect input file format!? (unknown extension in '"+fileName+"')");
       

--- a/pbrtParser/impl/syntactic/Parser.cpp
+++ b/pbrtParser/impl/syntactic/Parser.cpp
@@ -1,4 +1,3 @@
-#pragma optimize("", off)
 // ======================================================================== //
 // Copyright 2015-2019 Ingo Wald                                            //
 //                                                                          //
@@ -21,6 +20,7 @@
 #include <fstream>
 #include <sstream>
 #include <stack>
+#include <algorithm>
 // std
 #include <stdio.h>
 #include <string.h>

--- a/pbrtParser/impl/syntactic/Parser.cpp
+++ b/pbrtParser/impl/syntactic/Parser.cpp
@@ -1,3 +1,4 @@
+#pragma optimize("", off)
 // ======================================================================== //
 // Copyright 2015-2019 Ingo Wald                                            //
 //                                                                          //
@@ -848,17 +849,13 @@ namespace pbrt {
       }
     }
 
-
-#ifdef _WIN32
-    const char path_sep = '\\';
-#else
-    const char path_sep = '/';
-#endif
-
-    std::string pathOf(const std::string &fn)
+    std::string pathOf(std::string fn)
     {
-      size_t pos = fn.find_last_of(path_sep);
-      if (pos == std::string::npos) return std::string();
+      std::replace(fn.begin(), fn.end(), '\\', '/');
+      size_t pos = fn.find_last_of('/');
+      if (pos == std::string::npos) {
+        return std::string();
+      }
       return fn.substr(0,pos+1);
     }
 

--- a/pbrtParser/impl/syntactic/Scene.cpp
+++ b/pbrtParser/impl/syntactic/Scene.cpp
@@ -31,9 +31,9 @@ namespace pbrt {
   namespace syntactic {
   
     /*! parse the given file name, return parsed scene */
-    std::shared_ptr<Scene> Scene::parse(const std::string &fileName)
+    std::shared_ptr<Scene> Scene::parse(const std::string &fileName, const std::string &basePath)
     {
-      std::shared_ptr<Parser> parser = std::make_shared<Parser>();
+      std::shared_ptr<Parser> parser = std::make_shared<Parser>(basePath);
       parser->parse(fileName);
       return parser->getScene();
     }

--- a/pbrtParser/impl/syntactic/Scene.h
+++ b/pbrtParser/impl/syntactic/Scene.h
@@ -577,7 +577,7 @@ namespace pbrt {
         {}
 
       /*! parse the given file name, return parsed scene */
-      static std::shared_ptr<Scene> parse(const std::string &fileName);
+      static std::shared_ptr<Scene> parse(const std::string &fileName, const std::string &basePath = "");
     
       //! pretty-print scene info into a std::string 
       std::string toString(const int depth = 0) { return world->toString(depth); }

--- a/pbrtParser/include/pbrtParser/Scene.h
+++ b/pbrtParser/include/pbrtParser/Scene.h
@@ -999,6 +999,6 @@ namespace pbrt {
 
   /*! parse a pbrt file (using the pbrt_parser project, and convert
     the result over to a naivescenelayout */
-  PBRT_PARSER_INTERFACE Scene::SP importPBRT(const std::string &fileName);
+  PBRT_PARSER_INTERFACE Scene::SP importPBRT(const std::string &fileName, const std::string &basePath = "");
   
 } // ::pbrt


### PR DESCRIPTION
I'm finding that I need to set a base path for relative PBRT imports to work (eg the relative triangle meshes imported in the white room scene.), so I am now exposing that basepath through the public API, and defaulting it to an empty string.

Also am now passing names to material constructors when going from semantic -> syntactic