### PR TITLE
Fix binary file I/O on Win32

### DIFF
--- a/pbrtParser/impl/semantic/BinaryFileFormat.cpp
+++ b/pbrtParser/impl/semantic/BinaryFileFormat.cpp
@@ -90,7 +90,7 @@ namespace pbrt {
   struct BinaryReader {
 
     BinaryReader(const std::string &fileName)
-      : binFile(fileName)
+      : binFile(fileName, std::fstream::binary)
     {
       int formatTag;
       
@@ -142,6 +142,8 @@ namespace pbrt {
       vt = readVector<std::shared_ptr<T>>(); 
     }
     template<typename T> void read(T &t) { t = read<T>(); }
+
+    void read(Spectrum& s) { read(s.spd); }
 
     void read(std::string &t)
     {
@@ -297,10 +299,13 @@ namespace pbrt {
   template<>
   std::string BinaryReader::read()
   {
+    std::string s;
     int length = read<int>();
-    std::vector<char> cv(length);
-    copyBytes(&cv[0],length);
-    std::string s = std::string(cv.begin(),cv.end());
+    if (length) {
+      std::vector<char> cv(length);
+      copyBytes(&cv[0],length);
+      s = std::string(cv.begin(),cv.end());
+    }
     return s;
   }
 
@@ -322,7 +327,7 @@ namespace pbrt {
   struct BinaryWriter {
 
     BinaryWriter(const std::string &fileName)
-      : binFile(fileName)
+      : binFile(fileName, std::fstream::binary)
     {
       int formatTag = ourFormatTag;
       binFile.write((char*)&formatTag,sizeof(formatTag));
@@ -356,6 +361,11 @@ namespace pbrt {
     void write(std::shared_ptr<T> t)
     {
       write(serialize(t));
+    }
+
+    void write(const Spectrum& s)
+    {
+      write(s.spd);
     }
 
     void write(const std::string &t)


### PR DESCRIPTION
Potentially fixes https://github.com/ingowald/pbrt-parser/issues/27

Reading/writing on Windows fails if binary files are not opened with `fstream::binary`.

Fixed a bug where `&vector[0]` is `NULL` when `vector.size() == 0`.

Not sure if there are more bugs, would require exhaustive testing, I tested only with a few files..