### PR TITLE
compute LookAt transform the same way as pbrt does

### DIFF
--- a/pbrtParser/impl/syntactic/Parser.cpp
+++ b/pbrtParser/impl/syntactic/Parser.cpp
@@ -703,8 +703,8 @@ namespace pbrt {
           // scene->lookAt = std::make_shared<LookAt>(v0,v1,v2);
           affine3f xfm;
           xfm.l.vz = normalize(v1-v0);
-          xfm.l.vx = normalize(cross(xfm.l.vz,v2));
-          xfm.l.vy = cross(xfm.l.vx,xfm.l.vz);
+          xfm.l.vx = normalize(cross(v2,xfm.l.vz));
+          xfm.l.vy = cross(xfm.l.vz,xfm.l.vx);
           xfm.p    = v0;
         
           addTransform(inverse(xfm));


### PR DESCRIPTION
Computed this way the handedness of LookAt transform will match the handedness that is used by the renderer.

It is expected that right-handed renderer will produce the image the is flipped horizontally comparing to pbrt (which uses left-handed conventions). If it's desired to produce the same output then the image can be flipped at the end of pipeline. Another solution is to negate ```pbrt::Camera::frame.l.vx``` vector.

issue reference: https://github.com/ingowald/pbrt-parser/issues/31