### PR TITLE
fix macro redefinition

### DIFF
--- a/pbrtParser/include/pbrtParser/math.h
+++ b/pbrtParser/include/pbrtParser/math.h
@@ -20,7 +20,9 @@
 #  define _USE_MATH_DEFINES
 #endif
 #ifdef _WIN32
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
 #define __PRETTY_FUNCTION__ __FUNCSIG__
 #endif
 


### PR DESCRIPTION
This causes compilation warning for projects where _CRT_SECURE_NO_WARNINGS is already defined.