### PR TITLE
Update to Modern CMake Approach

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@
 ## limitations under the License.                                           ##
 ## ======================================================================== ##
 
-cmake_minimum_required(VERSION 2.8)
-
+cmake_minimum_required(VERSION 3.4)
+include(CMakePackageConfigHelpers)
 project(pbrtParser)
 
 set(pbrtParser_VERSION_MAJOR 2)
@@ -30,25 +30,23 @@ if(COMMAND cmake_policy)
   endif(${CMAKE_MAJOR_VERSION} EQUAL 3)
 endif(COMMAND cmake_policy)
 
-set(CMAKE_CXX_STANDARD 11)
-#set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -Wall)
-  
 if(NOT SET_UP_CONFIGURATIONS_DONE)
-    set(SET_UP_CONFIGURATIONS_DONE 1)
+  set(SET_UP_CONFIGURATIONS_DONE 1)
 
-    # No reason to set CMAKE_CONFIGURATION_TYPES if it's not a multiconfig generator
-    # Also no reason mess with CMAKE_BUILD_TYPE if it's a multiconfig generator.
-    if(CMAKE_CONFIGURATION_TYPES) # multiconfig generator?
-        set(CMAKE_CONFIGURATION_TYPES "Debug;Release;Profile" CACHE STRING "" FORCE) 
-    else()
-        if(NOT CMAKE_BUILD_TYPE)
-#            message("Defaulting to release build.")
-            set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
-        endif()
-        set_property(CACHE CMAKE_BUILD_TYPE PROPERTY HELPSTRING "Choose the type of build")
-        # set the valid options for cmake-gui drop-down list
-        set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release;Profile")
+  # TODO: Why do this?
+  # No reason to set CMAKE_CONFIGURATION_TYPES if it's not a multiconfig generator
+  # Also no reason mess with CMAKE_BUILD_TYPE if it's a multiconfig generator.
+  if(CMAKE_CONFIGURATION_TYPES) # multiconfig generator?
+    set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo;Profile" CACHE STRING "" FORCE) 
+  else()
+    if(NOT CMAKE_BUILD_TYPE)
+      #            message("Defaulting to release build.")
+      set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
     endif()
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY HELPSTRING "Choose the type of build")
+    # set the valid options for cmake-gui drop-down list
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release;Profile")
+  endif()
 endif()
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -59,24 +57,8 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
-# include out local 'include/' dir, we can include our two public
-# headers via pbrtParser/Scene.h and pbrtParser/math.h just the way an
-# app would include them through /usr/local/
-include_directories(${PROJECT_SOURCE_DIR}/pbrtParser/include)
-
-#include_directories(${PROJECT_SOURCE_DIR})
-#include_directories(${PROJECT_SOURCE_DIR}/internal/)
-
-#add_subdirectory(internal/ospcommon EXCLUDE_FROM_ALL)
-
 set(pbrtParser_VERSION "${pbrtParser_VERSION_MAJOR}.${pbrtParser_VERSION_MINOR}.${pbrtParser_VERSION_PATCH}")
 
-# syntactic-only parser
-#add_subdirectory(pbrtParser/syntactic)
-#add_subdirectory(pbrtParser/semantic)
 add_subdirectory(pbrtParser)
-
-#add_subdirectory(amalgamation)
-
 add_subdirectory(apps)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,12 +40,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 option(pbrtParser_ENABLE_UNITTESTS "Build unit tests" OFF)
 
-# include out local 'include/' dir, we can include our two public
-# headers via pbrtParser/Scene.h and pbrtParser/math.h just the way an
-# app would include them through /usr/local/
-# should be target include dirs
-#include_directories(${PROJECT_SOURCE_DIR}/pbrtParser/include)
-
 set(pbrtParser_VERSION "${pbrtParser_VERSION_MAJOR}.${pbrtParser_VERSION_MINOR}.${pbrtParser_VERSION_PATCH}")
 
 add_subdirectory(pbrtParser)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,25 +30,6 @@ if(COMMAND cmake_policy)
   endif(${CMAKE_MAJOR_VERSION} EQUAL 3)
 endif(COMMAND cmake_policy)
 
-if(NOT SET_UP_CONFIGURATIONS_DONE)
-  set(SET_UP_CONFIGURATIONS_DONE 1)
-
-  # TODO: Why do this?
-  # No reason to set CMAKE_CONFIGURATION_TYPES if it's not a multiconfig generator
-  # Also no reason mess with CMAKE_BUILD_TYPE if it's a multiconfig generator.
-  if(CMAKE_CONFIGURATION_TYPES) # multiconfig generator?
-    set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo;Profile" CACHE STRING "" FORCE) 
-  else()
-    if(NOT CMAKE_BUILD_TYPE)
-      #            message("Defaulting to release build.")
-      set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
-    endif()
-    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY HELPSTRING "Choose the type of build")
-    # set the valid options for cmake-gui drop-down list
-    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release;Profile")
-  endif()
-endif()
-
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE "Release")
 endif()

--- a/pbrtParser/CMakeLists.txt
+++ b/pbrtParser/CMakeLists.txt
@@ -44,7 +44,7 @@ set(SOURCES
   )
 
 # ------------------------------------------------------------------
-if (!_WIN32)
+if (NOT WIN32)
   # iw, 1/1/2020: On windows, passing any std::string, std::vector,
   # std::shared_ptr etc through dll boundaries is just a plain bad
   # idea, so we'll build the shared library only on linux

--- a/pbrtParser/CMakeLists.txt
+++ b/pbrtParser/CMakeLists.txt
@@ -53,6 +53,7 @@ set_target_properties(pbrtParser PROPERTIES
   CXX_VISIBILITY_PRESET hidden
   CXX_STANDARD 11
   CXX_STANDARD_REQUIRED ON
+  DEBUG_POSTFIX _debug
   )
 
 target_compile_definitions(pbrtParser PUBLIC PBRT_PARSER_DLL_INTERFACE)

--- a/pbrtParser/CMakeLists.txt
+++ b/pbrtParser/CMakeLists.txt
@@ -43,20 +43,46 @@ set(SOURCES
 add_library(pbrtParser SHARED
   ${SOURCES}
   )
-set_target_properties(pbrtParser PROPERTIES VERSION ${pbrtParser_VERSION})
-set_target_properties(pbrtParser PROPERTIES CXX_VISIBILITY_PRESET hidden)
+
+set_target_properties(pbrtParser PROPERTIES
+  VERSION ${pbrtParser_VERSION}
+  CXX_VISIBILITY_PRESET hidden
+  CXX_STANDARD 11
+  CXX_STANDARD_REQUIRED ON
+  )
+
 target_compile_definitions(pbrtParser PUBLIC PBRT_PARSER_DLL_INTERFACE)
+
+target_include_directories(pbrtParser PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  )
 
 # ------------------------------------------------------------------
 add_library(pbrtParser_static STATIC
   ${SOURCES}
   )
+
 set_target_properties(pbrtParser_static PROPERTIES VERSION ${pbrtParser_VERSION})
 
-# ------------------------------------------------------------------
-install(TARGETS pbrtParser DESTINATION lib)
-install(TARGETS pbrtParser_static DESTINATION lib)
+set_target_properties(pbrtParser_static PROPERTIES
+  VERSION ${pbrtParser_VERSION}
+  CXX_STANDARD 11
+  CXX_STANDARD_REQUIRED ON
+  )
 
-install(FILES include/pbrtParser/math.h DESTINATION include/pbrtParser)
-install(FILES include/pbrtParser/Scene.h DESTINATION include/pbrtParser)
+target_include_directories(pbrtParser_static PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  )
+
+# ------------------------------------------------------------------
+install(TARGETS pbrtParser pbrtParser_static EXPORT pbrtParserConfig
+  DESTINATION lib)
+
+install(FILES include/pbrtParser/math.h include/pbrtParser/Scene.h
+  DESTINATION include/pbrtParser)
+
+install(EXPORT pbrtParserConfig
+  DESTINATION lib/cmake/pbrtParser)
 


### PR DESCRIPTION
CMake properties are now set on the targets and we install a generated export header that users can point CMake to and pick up the library.