### PR TITLE
fix compilation error on win32 (CreateFile)

### DIFF
--- a/pbrtParser/impl/syntactic/FileMapping.cpp
+++ b/pbrtParser/impl/syntactic/FileMapping.cpp
@@ -37,7 +37,7 @@ namespace pbrt {
 
     FileMapping::FileMapping(const std::string &fname) : mapping(nullptr), num_bytes(0) {
 #ifdef _WIN32
-	  file = CreateFile(fname.c_str(), GENERIC_READ,
+	  file = CreateFileA(fname.c_str(), GENERIC_READ,
 	  		FILE_SHARE_READ, nullptr, OPEN_EXISTING,
 	  		FILE_ATTRIBUTE_NORMAL, nullptr);
 	  if (file == INVALID_HANDLE_VALUE) {


### PR DESCRIPTION
ANSI version should be used explicitly, otherwise it won't compile if CreateFile is defined as CreateFileW.