### PR TITLE
__PRETTY_FUNCTION__ is defned for llvm-mingw(clang) and MinGW gcc.

### DIFF
--- a/pbrtParser/include/pbrtParser/math.h
+++ b/pbrtParser/include/pbrtParser/math.h
@@ -23,8 +23,13 @@
 #ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
 #endif
+#if defined(_MSC_VER)
 #ifndef __PRETTY_FUNCTION__
 #  define __PRETTY_FUNCTION__ __FUNCSIG__
+#endif
+#else
+// Assume MinGW gcc or llvm-mingw(clang)
+// __PRETTY_FUNCTION__ is provided for such compilers
 #endif
 #endif
 


### PR DESCRIPTION
And `__PRETTY_FUNCTION__`  is not a macro(at least in case of clang) for such compilers so it cannot be checked with `ifndef`.